### PR TITLE
Remove Testing `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# @labcatr/labcommitr
-
-## 0.0.1
-
-### Patch Changes
-
-- 0f4a362: testagain
-- 1d0634f: Test of changeset
-- d18d84d: aaaah


### PR DESCRIPTION
This PR will remove the `CHANGELOG.md` file generated when testing the changeset bot.

There will be no side-effects of this change.