### PR TITLE
fix: include commit command files in published package

### DIFF
--- a/.changeset/fix-missing-config-command-in-package.md
+++ b/.changeset/fix-missing-config-command-in-package.md
@@ -2,11 +2,11 @@
 "@labcatr/labcommitr": patch
 ---
 
-fix: include config command files in published package
+fix: include config and commit command files in published package
 
 - Change package.json files field from directory to explicit file paths
-- Add dist/cli/commands/config.js and config.d.ts to files array
+- Add dist/cli/commands/config.js, config.d.ts, commit.js, and commit.d.ts to files array
 - Fixes ERR_MODULE_NOT_FOUND error when using lab commands
-- Config command was missing from published package causing runtime errors
-- Resolves issue where config.js file exists but wasn't included in npm package
+- Config and commit commands were missing from published package causing runtime errors
+- Resolves issue where command files exist but weren't included in npm package
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "dist/cli/program.js",
     "dist/cli/program.d.ts",
     "dist/cli/commands/commit",
+    "dist/cli/commands/commit.js",
+    "dist/cli/commands/commit.d.ts",
     "dist/cli/commands/config.js",
     "dist/cli/commands/config.d.ts",
     "dist/cli/commands/init",


### PR DESCRIPTION
• Add dist/cli/commands/commit.js and commit.d.ts to files array • Fixes ERR_MODULE_NOT_FOUND error for commit command • Same issue as config command - files exist but weren't included • Update changeset to reflect both config and commit fixes